### PR TITLE
Add intl extension to Dockerfile

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install exif \
     && docker-php-ext-install zip \
+    && docker-php-ext-install intl \
     && docker-php-source delete
 
 RUN apt-get update &&\


### PR DESCRIPTION
This pull request adds the `intl` extension to the Dockerfile. The `intl` extension is necessary for internationalization and localization support in PHP applications.