### PR TITLE
Remove unused code in EtablissementController.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ position-79196-firebase-adminsdk-fsrxt-4f4fdf9f0b.json
 /public/vendor/scribe
 composer.lock
 package-lock.json
+.scannerwork

--- a/app/Filament/Resources/EtablissementResource.php
+++ b/app/Filament/Resources/EtablissementResource.php
@@ -113,13 +113,13 @@ class EtablissementResource extends Resource
                         Forms\Components\Select::make('jour')
                             ->required()
                             ->options([
-                                'lundi' => 'Lundi',
-                                'mardi' => 'Mardi',
-                                'mercredi' => 'Mercredi',
-                                'jeudi' => 'Jeudi',
-                                'vendredi' => 'Vendredi',
-                                'samedi' => 'Samedi',
-                                'dimanche' => 'Dimanche',
+                                'Lundi' => 'Lundi',
+                                'Mardi' => 'Mardi',
+                                'Mercredi' => 'Mercredi',
+                                'Jeudi' => 'Jeudi',
+                                'Vendredi' => 'Vendredi',
+                                'Samedi' => 'Samedi',
+                                'Dimanche' => 'Dimanche',
                             ]),
                         Forms\Components\TextInput::make('plage_horaire')->required()->placeholder('Exemple: 08h00-12h00;14h00-18h00'),
                     ])

--- a/app/Http/Controllers/Api/EtablissementController.php
+++ b/app/Http/Controllers/Api/EtablissementController.php
@@ -813,7 +813,6 @@ class EtablissementController extends BaseController
             $etablissement->avis = $this->getCommentNumberByEtablissmeent($etablissement->id);
             $etablissement->count = $this->countOccurenceRatingInCommentTableByEtablissement($etablissement->id);
             $etablissement->batiment;
-            $etablissement['sousCategories'] = $etablissement->sousCategories;
 
             foreach ($etablissement->sousCategories as $sousCategories) {
                 $sousCategories->categorie;


### PR DESCRIPTION
This pull request removes unused code in the EtablissementController.php file. The code that is being removed is related to the 'sousCategories' property of the 'etablissement' object. This property is no longer needed and can be safely removed.