### PR TITLE
Update EtablissementController.php to use partial string matching for filtering by city

### DIFF
--- a/app/Http/Controllers/Api/EtablissementController.php
+++ b/app/Http/Controllers/Api/EtablissementController.php
@@ -621,7 +621,7 @@ class EtablissementController extends BaseController
         }
 
         if ($ville != null) {
-            $query->where('batiments.ville', '=', $ville);
+            $query->where('batiments.ville', 'like', '%' . $ville . '%');
         }
 
         $etablissements = $query->orderBy('distance', 'ASC')->distinct()->paginate(50);


### PR DESCRIPTION
This pull request updates the `EtablissementController.php` file to use partial string matching when filtering by city. Previously, an exact match was required, but now the code uses the `like` operator to match any city that contains the provided value. This improves the flexibility and accuracy of the filtering functionality.