### PR TITLE
Update Nominatim API endpoint

### DIFF
--- a/app/Http/Controllers/Api/EtablissementController.php
+++ b/app/Http/Controllers/Api/EtablissementController.php
@@ -865,7 +865,7 @@ class EtablissementController extends BaseController
         $existingOsmIds = $osmDatas->pluck('osm_id')->toArray();
 
         // Recherche des lieux dits via Nominatim
-        $nominatimResponse = Http::get('https://nominatim.position.cm/search', [
+        $nominatimResponse = Http::get('https://nominatim.openstreetmap.org/search', [
             'q' => $q,
             'format' => 'json',
             'polygon' => 0,
@@ -910,7 +910,7 @@ class EtablissementController extends BaseController
         }
 
         // Recherche des lieux dits via Nominatim
-        $nominatimResponse = Http::get('https://nominatim.position.cm/search', [
+        $nominatimResponse = Http::get('https://nominatim.openstreetmap.org/search', [
             'q' => $q,
             'format' => 'json',
             'polygon' => 0,


### PR DESCRIPTION
This pull request updates the Nominatim API endpoint in the EtablissementController.php file. The previous endpoint 'https://nominatim.position.cm/search' has been replaced with 'https://nominatim.openstreetmap.org/search'. This change ensures that the correct API is used for searching and retrieving location data.