### PR TITLE
Update Nominatim API endpoint in EtablissementController.php

### DIFF
--- a/app/Http/Controllers/Api/EtablissementController.php
+++ b/app/Http/Controllers/Api/EtablissementController.php
@@ -541,7 +541,7 @@ class EtablissementController extends BaseController
         }
 
         // Recherche des lieux dits via Nominatim
-        $nominatimResponse = Http::get('https://nominatim.position.cm/search', [
+        $nominatimResponse = Http::get('https://nominatim.openstreetmap.org/search', [
             'q' => $q,
             'format' => 'json',
             'polygon' => 0,


### PR DESCRIPTION
This pull request updates the Nominatim API endpoint in the EtablissementController.php file. The previous endpoint 'https://nominatim.position.cm/search' has been replaced with 'https://nominatim.openstreetmap.org/search'. This change ensures that the correct API endpoint is used for searching for places.