### PR TITLE
Update getNearbyEtablissement method in EtablissementController.php

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -51,7 +51,8 @@ Route::middleware('auth.apikey')->group(
         Route::get('etablissements/{id}', [App\Http\Controllers\Api\EtablissementController::class, 'show']);
         Route::get('search/etablissements', [App\Http\Controllers\Api\EtablissementController::class, 'search']);
         Route::get('search/nominatim', [App\Http\Controllers\Api\EtablissementController::class, 'nominatimSearch']);
-        Route::get('search/nominatim/reverse', [App\Http\Controllers\Api\EtablissementController::class, 'nominatimReverseSearch']);
+        Route::get('search/nominatim/reverse', [App\Http\Controllers\Api\EtablissementController::class, 'getNearbyEtablissement']);
+
 
         Route::get('globalsearch', [App\Http\Controllers\Api\EtablissementController::class, 'globalsearch']);
 


### PR DESCRIPTION
This pull request updates the `getNearbyEtablissement` method in the `EtablissementController.php` file. The method now calculates the distance between a given point and the buildings in the database using latitude and longitude coordinates. It also includes logic to return the closest establishment within a specified radius. Additionally, if no establishment is found, the method makes a request to the Nominatim API to retrieve nearby places. The pull request also updates the route for the `nominatimReverseSearch` endpoint to use the `getNearbyEtablissement` method.